### PR TITLE
Fetch homeworld

### DIFF
--- a/swapi-graphql/__tests__/schema.test.js
+++ b/swapi-graphql/__tests__/schema.test.js
@@ -11,7 +11,7 @@ import StarWarsApi from '../src/starwars-api.js';
 
 const mockResponse = {
     count: 1,
-    next: null,
+    hasNextPage: false,
     results: [{
         name: 'Luke Skywalker',
         height: '172',
@@ -22,7 +22,8 @@ const mockResponse = {
 ]};
 
 const mockPeopleResponse = {
-    ...mockResponse,
+    count: 1,
+    next: null,
     results: [{
         name: 'Luke Skywalker',
         height: '172',
@@ -40,7 +41,7 @@ const query = gql`
     query GetPeople ($page: Int!) {
         people (page: $page) {
             count
-            next
+            hasNextPage
             results {
                 name
                 height

--- a/swapi-graphql/__tests__/schema.test.js
+++ b/swapi-graphql/__tests__/schema.test.js
@@ -13,13 +13,28 @@ const mockResponse = {
     count: 1,
     next: null,
     results: [{
-        name: "Luke Skywalker",
-        height: "172",
-        mass: "77",
-        birth_year: "19BBY",
-        homeworld: "https://swapi.dev/api/planets/1/",
+        name: 'Luke Skywalker',
+        height: '172',
+        mass: '77',
+        birth_year: '19BBY',
+        origin: 'Tatooine',
         },
 ]};
+
+const mockPeopleResponse = {
+    ...mockResponse,
+    results: [{
+        name: 'Luke Skywalker',
+        height: '172',
+        mass: '77',
+        birth_year: '19BBY',
+        homeworld: 'https://swapi.dev/api/planets/1/',
+        },
+]};
+
+const mockHomeworldResponse = {
+    name: 'Tatooine',
+}
 
 const query = gql`
     query GetPeople ($page: Int!) {
@@ -31,7 +46,7 @@ const query = gql`
                 height
                 mass
                 birth_year
-                homeworld
+                origin
             }
         }
     }
@@ -50,7 +65,9 @@ describe('people resolver', () => {
     const contextValue = { dataSources: { starwarsApi } };
 
     test('returns people data', async () => {
-        starwarsApi.get = jest.fn(() => mockResponse);
+        starwarsApi.get = jest.fn()
+            .mockReturnValueOnce(mockPeopleResponse)
+            .mockReturnValueOnce(mockHomeworldResponse);
         const res = await server.executeOperation(
             { query, variables },
             { contextValue },
@@ -60,10 +77,30 @@ describe('people resolver', () => {
         expect(res.body.singleResult.data.people).toEqual(mockResponse);
     });
 
-    test('should throw an error if the Starwars Api request fails', async () => {
+    test('should throw an error if the Starwars Api people request fails', async () => {
         starwarsApi.get = jest.fn(() => {
             throw new Error('Error in HTTP Request/Response');
-        });
+            });
+        const res = await server.executeOperation(
+            { query, variables },
+            { contextValue },
+        );
+
+        /**
+         * Note that when testing, any errors in parsing, validating, and executing your GraphQL
+         * operation are returned in the nested errors field of the result. As with any GraphQL
+         * response, these errors are not thrown.
+         * https://www.apollographql.com/docs/apollo-server/testing/testing/#executing-queries-and-mutations
+         */
+        expect(res.body.singleResult.errors).toBeDefined();
+    });
+
+    test('should throw an error if the Starwars Api homeworld request fails', async () => {
+        starwarsApi.get = jest.fn()
+            .mockReturnValueOnce(mockPeopleResponse)
+            .mockImplementationOnce(() => {
+                throw new Error('Error in HTTP Request/Response');
+            });
         const res = await server.executeOperation(
             { query, variables },
             { contextValue },

--- a/swapi-graphql/src/schema.js
+++ b/swapi-graphql/src/schema.js
@@ -16,7 +16,7 @@ export const typeDefs = gql`
 
   type People {
     count: Int
-    next: String
+    hasNextPage: Boolean
     results: [Person]
   }
 
@@ -36,7 +36,11 @@ export const typeDefs = gql`
 export const resolvers = {
   Query: {
     async people(_, { page }, { dataSources }) {
-      return await dataSources.starwarsApi.getPeople(page);
+      const people = await dataSources.starwarsApi.getPeople(page);
+      return {
+        ...people,
+        hasNextPage: people.next ? true : false
+      }
     },
   },
   Person: {

--- a/swapi-graphql/src/schema.js
+++ b/swapi-graphql/src/schema.js
@@ -11,7 +11,7 @@ export const typeDefs = gql`
     height: String
     mass: String
     birth_year: String
-    homeworld: String
+    origin: String
   }
 
   type People {
@@ -37,6 +37,13 @@ export const resolvers = {
   Query: {
     async people(_, { page }, { dataSources }) {
       return await dataSources.starwarsApi.getPeople(page);
+    },
+  },
+  Person: {
+    async origin(person, _, { dataSources }) {
+      const planetId = person.homeworld.split('/').at(-2);
+      const homeworld = await dataSources.starwarsApi.getHomeworld(planetId);
+      return homeworld.name;
     },
   },
 };

--- a/swapi-graphql/src/starwars-api.js
+++ b/swapi-graphql/src/starwars-api.js
@@ -18,6 +18,20 @@ class StarWarsApi extends RESTDataSource {
         throw new Error('Starwars-Api: Failed to get people data');
       }
     }
+
+    async getHomeworld(planetId) {
+      if (!planetId) {
+        throw new Error('Starwars-Api: planetId is required to get homeworld');
+      }
+
+      try {
+        const response = await this.get(`planets/${planetId}`);
+        return response;
+      } catch (error) {
+        console.error(error);
+        throw new Error('Starwars-Api: Failed to get homeworld data');
+      }
+    }
 }
 
 export default StarWarsApi;


### PR DESCRIPTION
## Summary
This PR implements fetching the homeworld. It is currently a url, but we need to do another fetch and have this reflected in the resolver. Also, `next` is not directly used so implement `hasNextPage`.

## Testing
- [x] Manual
    - [x] Query GraphQL Playground and confirm `origin` is returned and `hasNextPage` is correct.
- [x] Update unit tests.

## Screenshots
![image](https://user-images.githubusercontent.com/131392424/234346960-a3062e25-79b7-4a98-9fc8-57bebfa196db.png)
